### PR TITLE
Support for TTL index (introduced in ArangoDB 3.5)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ Hash       | Exact matching          | `$collection->hashIndex($attributes, $ind
 Skip List  | Ranged matching         | `$collection->skiplistIndex($attributes, $indexOptions = [])`
 Persistent | Ranged matching         | `$collection->persistentIndex($attributes, $indexOptions = [])`
 Geo        | Location matching       | `$collection->geoIndex($attributes, $indexOptions = [])`
+TTL        | Auto-expiring documents | `$collection->ttlIndex($attributes, $indexOptions = [])`
 Fulltext   | (Partial) text matching | `$collection->fulltextIndex($attribute, $indexOptions = [])`
 
 See the [ArangoDB Documentation for more information](https://docs.arangodb.com/3.3/HTTP/Indexes/)

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -461,7 +461,7 @@ class Blueprint
      * 
      * @param $attributes
      * @param array $indexOptions
-     * @return Illuminate\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     public function ttlIndex($attributes, $indexOptions = [])
     {

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -457,6 +457,18 @@ class Blueprint
     }
 
     /**
+     * Create a TTL index for the table.
+     * 
+     * @param $attributes
+     * @param array $indexOptions
+     * @return Illuminate\Support\Fluent
+     */
+    public function ttlIndex($attributes, $indexOptions = [])
+    {
+        return $this->indexCommand('ttl', $attributes, $indexOptions);
+    }
+
+    /**
      * Specify a unique index for the table.
      *
      * @param  string|array  $columns
@@ -602,6 +614,7 @@ class Blueprint
             'HASH' => 'hash',
             'BTREE' => 'skiplist',
             'RTREE' => 'geo',
+            'TTL' => 'ttl',
         ];
         $algorithm = strtoupper($algorithm);
 

--- a/tests/Schema/SchemaBlueprintTest.php
+++ b/tests/Schema/SchemaBlueprintTest.php
@@ -96,6 +96,9 @@ class SchemaBlueprintTest extends TestCase
         $type = $blueprint->mapIndexType(null);
         $this->assertEquals('skiplist', $type);
 
+        $type = $blueprint->mapIndexType('TTL');
+        $this->assertEquals('ttl', $type);
+
         $type = $blueprint->mapIndexType('whatever');
         $this->assertEquals('skiplist', $type);
     }


### PR DESCRIPTION
Added the option of creating TTL type indexes in a migration