### PR TITLE
Run CI tests weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI tests
 
-on: [workflow_dispatch, push, pull_request]
+on: 
+  workflow_dispatch:
+  push:
+  pull_request:
+  schedule:
+  - cron: 0 6 * * 4
 
 env:
   DB_ENDPOINT: 'http://localhost:8529'


### PR DESCRIPTION
Run CI tests weekly to catch any breaking changes in dependencies early.